### PR TITLE
Size of multi select fields too small

### DIFF
--- a/wcfsetup/install/files/lib/system/condition/AbstractMultiSelectCondition.class.php
+++ b/wcfsetup/install/files/lib/system/condition/AbstractMultiSelectCondition.class.php
@@ -36,7 +36,7 @@ abstract class AbstractMultiSelectCondition extends AbstractSelectCondition {
 	protected function getFieldElement() {
 		$options = $this->getOptions();
 		
-		$fieldElement = '<select name="'.$this->fieldName.'[]" id="'.$this->fieldName.'" multiple size="'.(count($options, COUNT_RECURSIVE) > 10 ? 10 : count($options)).'">';
+		$fieldElement = '<select name="'.$this->fieldName.'[]" id="'.$this->fieldName.'" multiple size="'.(count($options, COUNT_RECURSIVE) > 10 ? 10 : count($options, COUNT_RECURSIVE)).'">';
 		foreach ($options as $key => $value) {
 			if (is_array($value)) {
 				$fieldElement .= $this->getOptGroupCode($key, $value);


### PR DESCRIPTION
If you have 10 or less options in a multi select condition field and using option groups, the field size is always 1.